### PR TITLE
feat: add JSON run-summary previews

### DIFF
--- a/.ai/AUTONOMOUS_STATE.md
+++ b/.ai/AUTONOMOUS_STATE.md
@@ -1,14 +1,14 @@
 # Autonomous State
 
 - Current roadmap version: v2
-- Current task ID: AUTO-016 — Resolve stale duplicate pull-request work
-- Current task status: DONE
-- Current branch: main
-- Last run timestamp: 2026-07-07T19:07:00+04:00
-- Last successful implementation commit hash: 1b370b8039a1bb235a550083dc150a12c48f51d8
-- Latest run summary: Reviewed all open pull requests after successful CI. Closed stale duplicate PR #2 because its installed-package CI hardening is already present on main. PR #3 remains open because it has merge conflicts after main advanced; its JSON run-summary preview CI passed and requires a clean conflict-resolving rebase before integration.
-- Files changed in the latest run: GitHub pull request #2 state; `.ai/AUTONOMOUS_STATE.md`.
-- Validation commands and results: GitHub Actions run 28873809513 for PR #2 and run 28874927536 for PR #3 both completed successfully. Main workflow configuration was reviewed and still pins actions, uses `contents: read`, runs Python 3.10–3.12, installs the package, smoke-tests `forge --version`, compiles source, and runs pytest. Local checkout execution remains unavailable because this environment cannot resolve github.com.
-- Current blockers: PR #3 is based on an older main commit and has merge conflicts in shared documentation/project-memory files; no conflict resolution was applied directly without reviewing a rebased diff.
-- Known risks and assumptions: PR #3 has validated feature behavior on its head commit, but compatibility with current main has not yet been independently validated after conflict resolution.
-- Recommended next task: Rebase or reconstruct PR #3 cleanly onto current main, preserve only its JSON run-summary feature and aligned docs/tests, then run CI before merge.
+- Current task ID: AUTO-017 — Reconstruct JSON run-summary preview on current main
+- Current task status: IN REVIEW
+- Current branch: auto/auto-017-json-run-summary-rebase
+- Last run timestamp: 2026-07-07T19:20:00+04:00
+- Last successful implementation commit hash: ac7fc142e272623422ab2b59c31ee60646972022
+- Latest run summary: Reconstructed the conflicted JSON run-summary work on a fresh branch from current main. The branch adds a shared preview-data builder, `forge run-summary --format json`, deterministic CLI JSON coverage, and dedicated format documentation.
+- Files changed in the latest run: `src/autonomous_forge/run_summary.py`, `src/autonomous_forge/cli.py`, `tests/test_cli.py`, `docs/JSON_RUN_SUMMARY.md`, `.ai/AUTONOMOUS_STATE.md`.
+- Validation commands and results: The original feature implementation passed GitHub Actions run 28874927536 before it diverged. This reconstructed branch has not yet received a fresh CI result. Static review confirms the JSON mode reuses the text-preview semantic fields and remains read-only.
+- Current blockers: README and historical project-memory updates remain pending because the repository contents write guard rejected the full README replacement in this environment; the branch-level feature and dedicated documentation are complete enough for CI review.
+- Known risks and assumptions: The new feature must pass CI against current main before merge. JSON is intentionally limited to run-summary preview data and does not add persistence, enforcement, repository writes, network behavior, command execution, diff inspection, commits, or environment reads.
+- Recommended next task: Observe replacement PR CI; if green, update the README and remaining project-memory records through a clean merge follow-up, then close obsolete PR #3.

--- a/docs/JSON_RUN_SUMMARY.md
+++ b/docs/JSON_RUN_SUMMARY.md
@@ -1,0 +1,35 @@
+# JSON Run-Summary Preview
+
+`forge run-summary --format json` prints the same read-only preview fields as the default text command in a machine-readable JSON object.
+
+## Usage
+
+```bash
+forge run-summary --plan .ai/AUTONOMOUS_PLAN.md --policy .forge/policy.md --format json
+```
+
+Use `--timestamp` to make output deterministic in scripts and tests:
+
+```bash
+forge run-summary --timestamp 2026-07-07T15:00:00+04:00 --format json
+```
+
+## Schema
+
+```json
+{
+  "run_timestamp": "<ISO-8601 timestamp with timezone>",
+  "selected_task": "<AUTO-### — title, or none>",
+  "task_status_before_run": "<status>",
+  "policy_status": "<readiness>",
+  "validation_plan": "PYTHONPATH=src python -m pytest",
+  "validation_result": "not run",
+  "changed_files_summary": "none",
+  "commit": "none",
+  "notes": "Read-only preview only; no run-summary file was written."
+}
+```
+
+## Safety boundary
+
+This is a formatting option only. It reads the same local plan and policy files as the text preview and does not write files, execute commands, inspect diffs, commit, push, call networks, read environment variables, or enforce policy decisions.

--- a/src/autonomous_forge/cli.py
+++ b/src/autonomous_forge/cli.py
@@ -108,6 +108,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="optional ISO-8601 timestamp to make preview output deterministic",
     )
+    run_summary_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="preview format: text (default) or JSON",
+    )
 
     inventory_parser = subparsers.add_parser(
         "inventory",
@@ -209,9 +215,21 @@ def _print_policy(policy_path: Path) -> int:
     return 0
 
 
-def _print_run_summary(plan_path: Path, policy_path: Path, timestamp: str | None) -> int:
+def _print_run_summary(
+    plan_path: Path,
+    policy_path: Path,
+    timestamp: str | None,
+    output_format: str,
+) -> int:
     try:
-        print(read_run_summary_preview(plan_path, policy_path, timestamp=timestamp))
+        print(
+            read_run_summary_preview(
+                plan_path,
+                policy_path,
+                timestamp=timestamp,
+                output_format=output_format,
+            )
+        )
     except FileNotFoundError:
         print(f"Plan file not found: {plan_path}")
         return 2
@@ -250,7 +268,12 @@ def main(argv: list[str] | None = None) -> int:
         return _print_policy(Path(args.policy))
 
     if args.command == "run-summary":
-        return _print_run_summary(Path(args.plan), Path(args.policy), args.timestamp)
+        return _print_run_summary(
+            Path(args.plan),
+            Path(args.policy),
+            args.timestamp,
+            args.format,
+        )
 
     if args.command == "inventory":
         return _print_inventory(Path(args.root))

--- a/src/autonomous_forge/run_summary.py
+++ b/src/autonomous_forge/run_summary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -37,6 +38,35 @@ def _policy_status(policy_text: str | None) -> str:
     return "present and readable"
 
 
+def build_run_summary_data(
+    plan_text: str,
+    policy_text: str | None = None,
+    *,
+    timestamp: str | None = None,
+    validation_plan: str = DEFAULT_VALIDATION_PLAN,
+    validation_result: str = "not run",
+    changed_files_summary: str = "none",
+    commit: str = "none",
+    notes: str = DEFAULT_NOTES,
+) -> dict[str, str]:
+    """Return structured preview fields without writing a run-summary file."""
+    tasks = parse_plan_tasks(plan_text)
+    selected_task = select_eligible_task(tasks)
+    run_timestamp = timestamp or datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+    return {
+        "run_timestamp": run_timestamp,
+        "selected_task": _format_selected_task(selected_task),
+        "task_status_before_run": _format_task_status(selected_task),
+        "policy_status": _policy_status(policy_text),
+        "validation_plan": validation_plan,
+        "validation_result": validation_result,
+        "changed_files_summary": changed_files_summary,
+        "commit": commit,
+        "notes": notes,
+    }
+
+
 def build_run_summary_preview(
     plan_text: str,
     policy_text: str | None = None,
@@ -48,23 +78,44 @@ def build_run_summary_preview(
     commit: str = "none",
     notes: str = DEFAULT_NOTES,
 ) -> str:
-    """Return the documented run-summary shape without writing files."""
-    tasks = parse_plan_tasks(plan_text)
-    selected_task = select_eligible_task(tasks)
-    run_timestamp = timestamp or datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+    """Return the documented human-readable run-summary shape without writing files."""
+    summary = build_run_summary_data(
+        plan_text,
+        policy_text,
+        timestamp=timestamp,
+        validation_plan=validation_plan,
+        validation_result=validation_result,
+        changed_files_summary=changed_files_summary,
+        commit=commit,
+        notes=notes,
+    )
 
     return "\n".join(
         [
-            f"Run timestamp: {run_timestamp}",
-            f"Selected task: {_format_selected_task(selected_task)}",
-            f"Task status before run: {_format_task_status(selected_task)}",
-            f"Policy status: {_policy_status(policy_text)}",
-            f"Validation plan: {validation_plan}",
-            f"Validation result: {validation_result}",
-            f"Changed files summary: {changed_files_summary}",
-            f"Commit: {commit}",
-            f"Notes: {notes}",
+            f"Run timestamp: {summary['run_timestamp']}",
+            f"Selected task: {summary['selected_task']}",
+            f"Task status before run: {summary['task_status_before_run']}",
+            f"Policy status: {summary['policy_status']}",
+            f"Validation plan: {summary['validation_plan']}",
+            f"Validation result: {summary['validation_result']}",
+            f"Changed files summary: {summary['changed_files_summary']}",
+            f"Commit: {summary['commit']}",
+            f"Notes: {summary['notes']}",
         ]
+    )
+
+
+def build_run_summary_preview_json(
+    plan_text: str,
+    policy_text: str | None = None,
+    *,
+    timestamp: str | None = None,
+) -> str:
+    """Return a deterministic JSON run-summary preview without writing files."""
+    return json.dumps(
+        build_run_summary_data(plan_text, policy_text, timestamp=timestamp),
+        indent=2,
+        ensure_ascii=False,
     )
 
 
@@ -73,8 +124,12 @@ def read_run_summary_preview(
     policy_path: Path = Path(".forge/policy.md"),
     *,
     timestamp: str | None = None,
+    output_format: str = "text",
 ) -> str:
     """Read local files and build a run-summary preview without writing files."""
     plan_text = plan_path.read_text(encoding="utf-8")
     policy_text = policy_path.read_text(encoding="utf-8") if policy_path.exists() else None
+
+    if output_format == "json":
+        return build_run_summary_preview_json(plan_text, policy_text, timestamp=timestamp)
     return build_run_summary_preview(plan_text, policy_text, timestamp=timestamp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from autonomous_forge.cli import main
 
 
@@ -128,17 +130,7 @@ Status: DONE
     state.write_text("# State\n", encoding="utf-8")
     policy.write_text(VALID_POLICY, encoding="utf-8")
 
-    assert main(
-        [
-            "report",
-            "--plan",
-            str(plan),
-            "--state",
-            str(state),
-            "--policy",
-            str(policy),
-        ]
-    ) == 0
+    assert main(["report", "--plan", str(plan), "--state", str(state), "--policy", str(policy)]) == 0
 
     output = capsys.readouterr().out
     assert "Autonomous Forge dry-run report" in output
@@ -153,26 +145,13 @@ def test_report_command_marks_missing_policy(tmp_path, capsys):
     plan = tmp_path / "AUTONOMOUS_PLAN.md"
     state = tmp_path / "AUTONOMOUS_STATE.md"
     missing_policy = tmp_path / "missing-policy.md"
-    plan.write_text(
-        """### AUTO-010 — Ready task
+    plan.write_text("""### AUTO-010 — Ready task
 Priority: P2
 Status: TODO
-""",
-        encoding="utf-8",
-    )
+""", encoding="utf-8")
     state.write_text("# State\n", encoding="utf-8")
 
-    assert main(
-        [
-            "report",
-            "--plan",
-            str(plan),
-            "--state",
-            str(state),
-            "--policy",
-            str(missing_policy),
-        ]
-    ) == 0
+    assert main(["report", "--plan", str(plan), "--state", str(state), "--policy", str(missing_policy)]) == 0
 
     output = capsys.readouterr().out
     assert "Policy file: missing" in output
@@ -182,13 +161,10 @@ def test_report_command_marks_malformed_policy(tmp_path, capsys):
     plan = tmp_path / "AUTONOMOUS_PLAN.md"
     state = tmp_path / "AUTONOMOUS_STATE.md"
     policy = tmp_path / "policy.md"
-    plan.write_text(
-        """### AUTO-010 — Ready task
+    plan.write_text("""### AUTO-010 — Ready task
 Priority: P2
 Status: TODO
-""",
-        encoding="utf-8",
-    )
+""", encoding="utf-8")
     state.write_text("# State\n", encoding="utf-8")
     policy.write_text(
         """## Allowed paths
@@ -206,17 +182,7 @@ src/**
         encoding="utf-8",
     )
 
-    assert main(
-        [
-            "report",
-            "--plan",
-            str(plan),
-            "--state",
-            str(state),
-            "--policy",
-            str(policy),
-        ]
-    ) == 0
+    assert main(["report", "--plan", str(plan), "--state", str(state), "--policy", str(policy)]) == 0
 
     output = capsys.readouterr().out
     assert "Policy file: malformed:" in output
@@ -251,17 +217,10 @@ def test_run_summary_command_prints_read_only_preview(tmp_path, capsys):
     plan.write_text(VALID_PLAN, encoding="utf-8")
     policy.write_text(VALID_POLICY, encoding="utf-8")
 
-    assert main(
-        [
-            "run-summary",
-            "--plan",
-            str(plan),
-            "--policy",
-            str(policy),
-            "--timestamp",
-            "2026-07-07T15:00:00+04:00",
-        ]
-    ) == 0
+    assert main([
+        "run-summary", "--plan", str(plan), "--policy", str(policy),
+        "--timestamp", "2026-07-07T15:00:00+04:00",
+    ]) == 0
 
     output = capsys.readouterr().out
     assert "Run timestamp: 2026-07-07T15:00:00+04:00" in output
@@ -270,3 +229,28 @@ def test_run_summary_command_prints_read_only_preview(tmp_path, capsys):
     assert "Policy status: present and readable" in output
     assert "Validation result: not run" in output
     assert "Commit: none" in output
+
+
+def test_run_summary_command_prints_machine_readable_json_preview(tmp_path, capsys):
+    plan = tmp_path / "AUTONOMOUS_PLAN.md"
+    policy = tmp_path / "policy.md"
+    plan.write_text(VALID_PLAN, encoding="utf-8")
+    policy.write_text(VALID_POLICY, encoding="utf-8")
+
+    assert main([
+        "run-summary", "--plan", str(plan), "--policy", str(policy),
+        "--timestamp", "2026-07-07T15:00:00+04:00", "--format", "json",
+    ]) == 0
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary == {
+        "run_timestamp": "2026-07-07T15:00:00+04:00",
+        "selected_task": "AUTO-010 — Ready task",
+        "task_status_before_run": "TODO",
+        "policy_status": "present and readable",
+        "validation_plan": "PYTHONPATH=src python -m pytest",
+        "validation_result": "not run",
+        "changed_files_summary": "none",
+        "commit": "none",
+        "notes": "Read-only preview only; no run-summary file was written.",
+    }


### PR DESCRIPTION
## Summary
- reconstructs the previously conflicted JSON run-summary work from current `main`
- adds `forge run-summary --format json` while keeping text as the default
- uses one shared preview-data builder so text and JSON carry the same fields
- adds deterministic CLI coverage and dedicated JSON-format documentation

## Safety
The new format is read-only. It does not write execution history, run commands, inspect diffs, commit, push, call networks, read environment variables, or enforce policy decisions.

## Validation
- original feature implementation passed GitHub Actions before it diverged
- this clean branch is based on current `main` and requires fresh CI before merge

## Follow-up
- update README and remaining historical project-memory records after CI confirms the clean integration
- close obsolete PR #3 after this replacement is merged