### PR TITLE
fix: preserve hidden path tokens like `.env` when trailing punctuation follows

### DIFF
--- a/src/autonomous_forge/proposal.py
+++ b/src/autonomous_forge/proposal.py
@@ -20,7 +20,14 @@ def _split_expected_areas(expected_files: str) -> tuple[str, ...]:
 
     areas: list[str] = []
     for raw_part in normalized.splitlines():
-        part = raw_part.strip().strip("`").rstrip(";.").strip()
+        part = raw_part.strip()
+        # Peel trailing sentence punctuation and surrounding backticks in any
+        # order so tokens like ``.env`.`` from the roadmap normalize to `.env`
+        # instead of leaving a dangling backtick after the leading period.
+        previous = None
+        while part and part != previous:
+            previous = part
+            part = part.strip("`").rstrip(";.,").strip()
         if not part or part.lower() == "not documented":
             continue
         areas.append(part)

--- a/tests/test_dotfile_paths.py
+++ b/tests/test_dotfile_paths.py
@@ -28,10 +28,38 @@ Risks or assumptions: Output remains read-only.
 """
 
 
+PLAN_TRAILING_COMMA = """### AUTO-998 — Handle trailing commas in file lists
+Priority: P1
+Status: TODO
+Goal: Preserve tokens when the roadmap uses trailing commas.
+Why it matters: Roadmap authors may use Oxford-style trailing commas.
+Scope: Keep hidden file names intact.
+Expected files or areas: `src/example.py`, `.env`,
+Acceptance criteria: Planned areas retain the leading period.
+Validation: Run pytest.
+Risks or assumptions: Output remains read-only.
+"""
+
+
 def test_change_proposal_preserves_hidden_file_path(tmp_path):
     state = tmp_path / "state.md"
     state.write_text("# State\n", encoding="utf-8")
     plan_data = build_repository_plan_data(PLAN, POLICY, state_path=state, root=tmp_path)
+
+    proposal = build_change_proposal_data(plan_data)
+
+    assert proposal["planned_file_areas"] == ["src/example.py", ".env"]
+
+
+def test_change_proposal_preserves_hidden_file_path_with_trailing_comma(tmp_path):
+    state = tmp_path / "state.md"
+    state.write_text("# State\n", encoding="utf-8")
+    plan_data = build_repository_plan_data(
+        PLAN_TRAILING_COMMA,
+        POLICY,
+        state_path=state,
+        root=tmp_path,
+    )
 
     proposal = build_change_proposal_data(plan_data)
 


### PR DESCRIPTION
## Status

Closed as integrated directly on `main` during AUTO-059.

The useful parser fix and trailing-comma regression coverage were applied to `src/autonomous_forge/proposal.py` and `tests/test_dotfile_paths.py` without creating or merging a branch, matching the current main-only stewardship workflow.

## Notes

- Mainline now peels surrounding backticks and trailing punctuation iteratively for planned file-area tokens.
- Hidden policy paths such as `.env` remain exact when roadmap text uses patterns like ``.env`.`` or ``.env`,``.
- Local pytest execution in the automation environment remained unavailable, so validation was static plus committed deterministic tests.