### PR TITLE
fix: refuse to silently overwrite existing run-history records

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ forge preflight-readiness \
 
 ## Opt-in local run-history write
 
-`forge run-history-write` is the only current product command that writes a file. It writes exactly one JSON record under `.ai/run-history/`, requires `--confirm-write`, and refuses blocked preflight readiness.
+`forge run-history-write` is the only current product command that writes a file. It writes exactly one JSON record under `.ai/run-history/`, requires `--confirm-write`, refuses blocked preflight readiness, and refuses to silently replace an existing record unless `--allow-overwrite` is also passed.
 
 ```bash
 forge run-history-write \

--- a/docs/RUN_HISTORY_WRITES.md
+++ b/docs/RUN_HISTORY_WRITES.md
@@ -25,8 +25,11 @@ The writer refuses to persist a record unless all of these are true:
 - The output path stays inside the repository root.
 - The output path is under `.ai/run-history/`.
 - The output path uses a `.json` extension.
+- The output path does not already exist, unless `--allow-overwrite` is also passed.
 
 Relative output paths are resolved under `--root`, so `.ai/run-history/latest.json` is valid when `--root .` points at the repository root.
+
+Because durable run-history records are the project's persistent memory, `run-history-write` refuses to silently replace an existing file. Pass `--allow-overwrite` when the caller has reviewed the existing record and explicitly wants to replace it.
 
 ## Record shape
 
@@ -42,4 +45,4 @@ The persisted JSON payload includes:
 
 ## Current limitations
 
-This command writes a local history artifact only. It does not append to a long-lived index, rotate files, inspect Git state, compare existing records, detect secrets, run tests, or validate the repository after writing. Callers should still review the output and run the repository test suite separately.
+This command writes a local history artifact only. It does not append to a long-lived index, rotate files, inspect Git state, compare existing records, detect secrets, run tests, or validate the repository after writing. Callers should still review the output and run the repository test suite separately. Overwriting an existing record still requires the explicit `--allow-overwrite` flag.

--- a/src/autonomous_forge/cli.py
+++ b/src/autonomous_forge/cli.py
@@ -167,6 +167,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="required acknowledgement that this command writes one local JSON file",
     )
+    run_history_write_parser.add_argument(
+        "--allow-overwrite",
+        action="store_true",
+        help="allow replacing an existing local run-history JSON record",
+    )
 
     review_files_parser = subparsers.add_parser(
         "review-files",
@@ -406,6 +411,7 @@ def _write_run_history(
     root: Path,
     output_path: Path,
     confirm_write: bool,
+    allow_overwrite: bool,
 ) -> int:
     try:
         result = write_run_history_record(
@@ -415,6 +421,7 @@ def _write_run_history(
             root=root,
             output_path=output_path,
             confirm_write=confirm_write,
+            allow_overwrite=allow_overwrite,
         )
     except FileNotFoundError as exc:
         print(f"Required file not found: {exc.filename}")
@@ -484,6 +491,7 @@ def main(argv: list[str] | None = None) -> int:
             Path(args.root),
             Path(args.output),
             args.confirm_write,
+            args.allow_overwrite,
         )
 
     if args.command == "review-files":

--- a/src/autonomous_forge/run_history_writer.py
+++ b/src/autonomous_forge/run_history_writer.py
@@ -29,7 +29,12 @@ def _resolve_inside(root: Path, path: Path | str) -> tuple[Path, Path]:
     return resolved_root, resolved_path
 
 
-def _validate_output_path(root: Path, output_path: Path | str) -> Path:
+def _validate_output_path(
+    root: Path,
+    output_path: Path | str,
+    *,
+    allow_overwrite: bool = False,
+) -> Path:
     """Validate the dedicated local history path before writing."""
     resolved_root, resolved_output = _resolve_inside(root, output_path)
     history_dir = (resolved_root / ".ai" / "run-history").resolve()
@@ -43,6 +48,10 @@ def _validate_output_path(root: Path, output_path: Path | str) -> Path:
         raise RunHistoryWriteError("output path must use a .json extension")
     if resolved_output.exists() and resolved_output.is_dir():
         raise RunHistoryWriteError("output path points to a directory")
+    if resolved_output.exists() and not allow_overwrite:
+        raise RunHistoryWriteError(
+            "output path already exists; pass --allow-overwrite to replace it"
+        )
     return resolved_output
 
 
@@ -97,12 +106,15 @@ def write_run_history_record(
     confirm_write: bool,
     state_path: Path | None = None,
     root: Path = Path("."),
+    allow_overwrite: bool = False,
 ) -> dict[str, Any]:
     """Write one local run-history JSON record only after explicit confirmation."""
     if not confirm_write:
         raise RunHistoryWriteError("--confirm-write is required")
 
-    safe_output = _validate_output_path(root, output_path)
+    safe_output = _validate_output_path(
+        root, output_path, allow_overwrite=allow_overwrite
+    )
     payload = build_run_history_write_payload(
         plan_text,
         policy_text,

--- a/tests/test_run_history_writer.py
+++ b/tests/test_run_history_writer.py
@@ -153,6 +153,91 @@ def test_write_run_history_record_refuses_blocked_preflight(tmp_path):
         )
 
 
+def test_write_run_history_record_refuses_silent_overwrite(tmp_path):
+    _write_required_inventory(tmp_path)
+    output = tmp_path / ".ai" / "run-history" / "record.json"
+
+    write_run_history_record(
+        VALID_PLAN,
+        VALID_POLICY,
+        root=tmp_path,
+        output_path=output,
+        confirm_write=True,
+    )
+    output.write_text('{"human_edited": true}\n', encoding="utf-8")
+
+    with pytest.raises(RunHistoryWriteError, match="--allow-overwrite"):
+        write_run_history_record(
+            VALID_PLAN,
+            VALID_POLICY,
+            root=tmp_path,
+            output_path=output,
+            confirm_write=True,
+        )
+
+    assert '"human_edited"' in output.read_text(encoding="utf-8")
+
+
+def test_write_run_history_record_overwrites_when_allowed(tmp_path):
+    _write_required_inventory(tmp_path)
+    output = tmp_path / ".ai" / "run-history" / "record.json"
+
+    write_run_history_record(
+        VALID_PLAN,
+        VALID_POLICY,
+        root=tmp_path,
+        output_path=output,
+        confirm_write=True,
+    )
+    output.write_text('{"human_edited": true}\n', encoding="utf-8")
+
+    result = write_run_history_record(
+        VALID_PLAN,
+        VALID_POLICY,
+        root=tmp_path,
+        output_path=output,
+        confirm_write=True,
+        allow_overwrite=True,
+    )
+
+    assert result["path"] == str(output.resolve())
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["schema_version"] == "run-history/v1"
+    assert data["record"]["task"]["id"] == "AUTO-030"
+
+
+def test_run_history_write_command_refuses_silent_overwrite(tmp_path, capsys):
+    _write_required_inventory(tmp_path)
+    plan = tmp_path / "plan.md"
+    policy = tmp_path / "policy.md"
+    state = tmp_path / "state.md"
+    output = tmp_path / ".ai" / "run-history" / "record.json"
+    plan.write_text(VALID_PLAN, encoding="utf-8")
+    policy.write_text(VALID_POLICY, encoding="utf-8")
+    state.write_text("state", encoding="utf-8")
+
+    args = [
+        "run-history-write",
+        "--plan", str(plan),
+        "--policy", str(policy),
+        "--state", str(state),
+        "--root", str(tmp_path),
+        "--output", str(output),
+        "--confirm-write",
+    ]
+    assert main(args) == 0
+    output.write_text('{"human_edited": true}\n', encoding="utf-8")
+
+    assert main(args) == 2
+    printed = capsys.readouterr().out
+    assert "already exists" in printed
+    assert '"human_edited"' in output.read_text(encoding="utf-8")
+
+    assert main(args + ["--allow-overwrite"]) == 0
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["record"]["task"]["id"] == "AUTO-030"
+
+
 def test_run_history_write_command_writes_record(tmp_path, capsys):
     _write_required_inventory(tmp_path)
     plan = tmp_path / "plan.md"


### PR DESCRIPTION
## Summary

`forge run-history-write` (added in AUTO-030) writes into `.ai/run-history/`, which `docs/RUN_HISTORY_WRITES.md` frames as the project's durable local memory. Today the writer will silently replace an existing record on any re-run against the same `--output` path \u2014 including a human-edited one. That contradicts the "durable" framing and the project's cautious safety philosophy.

## What this changes

- Adds an explicit `--allow-overwrite` flag (default off).
- Refuses the write with `RunHistoryWriteError("output path already exists; pass --allow-overwrite to replace it")` when the target already exists and `--allow-overwrite` is not passed.
- Threads the flag through the CLI so scripted callers can opt in after reviewing the existing record.
- Updates `docs/RUN_HISTORY_WRITES.md` and `README.md` to document the new safety gate.

## Repro before this PR

```python
write_run_history_record(...)                       # writes rec.json
Path('rec.json').write_text('{"human_edited": true}\n')
write_run_history_record(...)                       # silently clobbers the edit
```

## Tests

Three new deterministic tests in `tests/test_run_history_writer.py`:

- `test_write_run_history_record_refuses_silent_overwrite`
- `test_write_run_history_record_overwrites_when_allowed`
- `test_run_history_write_command_refuses_silent_overwrite` (also verifies the CLI path)

Full suite (`PYTHONPATH=src python -m pytest -q`): **89 passed, 1 unrelated pre-existing failure** in `tests/test_dotfile_paths.py` (covered by a separate open PR).

## Safety boundary

- Local-first. No network. No external commands. No git or diff inspection. No policy enforcement.
- Only touches `src/autonomous_forge/`, `tests/`, `docs/`, and `README.md` \u2014 all allowed paths per `.forge/policy.md`.
- The default behavior becomes *more* conservative (write refuses instead of silently replacing), which matches the project's overall stance.