### PR TITLE
ci: fix roadmap priority lint failure

### DIFF
--- a/.ai/AUTONOMOUS_PLAN.md
+++ b/.ai/AUTONOMOUS_PLAN.md
@@ -33,7 +33,7 @@ It does not yet append to a hash-linked long-lived history index, automatically 
 ## Roadmap v1 — Completed foundation
 
 ### AUTO-001 — Local CLI, roadmap parsing, task selection, and dry-run reports through AUTO-004
-Priority: P1-P2
+Priority: P1
 Status: DONE
 
 Goal: Establish an installable local CLI that can parse roadmap tasks, select the next eligible item deterministically, and report repository state without changing files.
@@ -48,7 +48,7 @@ Notes: Historical detailed task records remain available in repository history.
 ## Roadmap v2 — Completed safety and reporting surface
 
 ### AUTO-005 — Policy, linting, inventory, and run-summary previews through AUTO-017
-Priority: P1-P3
+Priority: P1
 Status: DONE
 
 Goal: Establish policy parsing, roadmap linting, contributor guidance, command contracts, repository inventory, and run-summary preview behavior.


### PR DESCRIPTION
## Summary
- fixes the failing `Validate repository planning inputs` step shown on Test #834 for Python 3.10, 3.11, and 3.12
- replaces historical grouped roadmap priority ranges (`P1-P2`, `P1-P3`) with supported single priority values (`P1`)

## Root cause
`forge lint-plan` only accepts `P0`, `P1`, `P2`, or `P3` as task priority values. The grouped historical roadmap blocks had lint-incompatible range values, so CI failed before later smoke tests and pytest could run.

## Verification
- Static review of `src/autonomous_forge/plan.py` confirmed supported priority values are single labels only.
- Static review of `.ai/AUTONOMOUS_PLAN.md` confirmed the two unsupported range values were the remaining lint blockers.
- Local command execution is unavailable from this runtime, so CI should be rerun on this PR to confirm the full matrix.